### PR TITLE
feat: add Lampstand root hints RPC for Smart Tree integration

### DIFF
--- a/.github/workflows/lampstand-rpc.yml
+++ b/.github/workflows/lampstand-rpc.yml
@@ -1,0 +1,36 @@
+name: Lampstand RPC Contract
+
+on:
+  pull_request:
+    paths:
+      - "lampstand/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/lampstand-rpc.yml"
+  push:
+    branches:
+      - main
+      - "socioprophet/**"
+    paths:
+      - "lampstand/**"
+      - "tests/**"
+      - "pyproject.toml"
+      - ".github/workflows/lampstand-rpc.yml"
+
+jobs:
+  rpc-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: python -m pip install -e .
+
+      - name: Run local query and root hints tests
+        run: python -m unittest tests.test_local_query_adapter -v

--- a/lampstand/cli.py
+++ b/lampstand/cli.py
@@ -129,6 +129,17 @@ def cmd_health(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_roots(args: argparse.Namespace) -> int:
+    transport = _choose_rpc_transport(args.rpc)
+    sock = Path(args.socket) if args.socket else default_socket_path()
+    client = _try_rpc_client(transport, sock)
+    if client is None:
+        print(json.dumps({"roots": [], "adapter_mode": "unavailable", "error": "daemon_unreachable"}, indent=2, sort_keys=True))
+        return 2
+    print(json.dumps(client.root_hints(), indent=2, sort_keys=True))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="lampstand", description="Local file indexer/search prototype")
     p.add_argument("--db", help="Path to sqlite DB (default: ~/.local/share/lampstand/index.sqlite3)")
@@ -170,6 +181,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_health = sub.add_parser("health", help="Daemon health (RPC)")
     p_health.set_defaults(fn=cmd_health)
+
+    p_roots = sub.add_parser("roots", help="Lampstand-owned local roots (RPC)")
+    p_roots.set_defaults(fn=cmd_roots)
 
     return p
 

--- a/lampstand/daemon.py
+++ b/lampstand/daemon.py
@@ -48,6 +48,7 @@ def run_daemon(
     ensure_dirs()
     db_path = db_path or default_db_path()
     sock_path = rpc_socket_path or default_socket_path()
+    root_list = [Path(p).expanduser().resolve() for p in roots]
 
     db = IndexDB(db_path)
     db.open()
@@ -64,7 +65,7 @@ def run_daemon(
         watcher_opts = WatchOptions(scan_options=scan_opts, reconcile_interval_s=reconcile_interval_s)
 
         # Initial scan for baseline correctness.
-        full_scan(indexer, roots, opts=scan_opts)
+        full_scan(indexer, root_list, opts=scan_opts)
 
         # Start RPC server (read-mostly).
         # NOTE: rpc_transport can be 'auto'; the runtime will resolve it.
@@ -76,18 +77,19 @@ def run_daemon(
             db_path=db_path,
             socket_path=sock_path,
             request_reindex=None,  # wired later once we have a journal/work queue
+            get_roots=lambda: list(root_list),
             get_health_details=lambda: {
                 "rpc_transport": resolved_transport['value'],
                 "requested_rpc_transport": rpc_transport,
                 "rpc_socket": str(sock_path),
-                "roots": [str(p) for p in roots],
+                "roots": [str(p) for p in root_list],
             },
         )
 
         # Record the actual transport selected by runtime (important if requested was 'auto').
         resolved_transport['value'] = getattr(rpc, 'transport', rpc_transport)
 
-        tw = TreeWatcher(indexer, roots, opts=watcher_opts)
+        tw = TreeWatcher(indexer, root_list, opts=watcher_opts)
         try:
             tw.run()
         finally:

--- a/lampstand/rpc/client.py
+++ b/lampstand/rpc/client.py
@@ -48,5 +48,8 @@ class RpcClient:
     def health(self) -> dict[str, Any]:
         return self._call("Health", {})
 
+    def root_hints(self) -> dict[str, Any]:
+        return self._call("RootHints", {})
+
     def reindex(self, paths: list[str]) -> dict[str, Any]:
         return self._call("Reindex", {"paths": paths})

--- a/lampstand/rpc/messages.py
+++ b/lampstand/rpc/messages.py
@@ -46,6 +46,35 @@ class ReindexResponse:
 
 
 # ---------------------------------------------------------------------------
+# Root hints — local-state root discovery for Smart Tree and other adapters
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RootHint:
+    """A Lampstand-owned local root that may be enriched by downstream tools."""
+
+    source_root_id: str
+    path: str
+    root_kind: str = "local_root"
+    freshness: Optional[dict[str, Any]] = None
+    classification: str = "local_only"
+    handling_tags: tuple[str, ...] = ("local-only",)
+
+
+@dataclass(frozen=True)
+class RootHintsResponse:
+    """Read-only list of Lampstand-owned roots.
+
+    Downstream tools must treat these as hints, not authorization. Policy Fabric
+    still decides whether a specific root may be enriched.
+    """
+
+    roots: tuple[RootHint, ...]
+    adapter_mode: str = "rpc"
+
+
+# ---------------------------------------------------------------------------
 # Local query adapter — Lattice FederatedQueryPlane / lampstand-local-query
 # ---------------------------------------------------------------------------
 

--- a/lampstand/rpc/runtime.py
+++ b/lampstand/rpc/runtime.py
@@ -24,6 +24,7 @@ def start_rpc_server(
     socket_path: Optional[Path],
     request_reindex: Optional[Callable[[list[Path]], int]] = None,
     get_health_details: Optional[Callable[[], dict]] = None,
+    get_roots: Optional[Callable[[], list[Path]]] = None,
 ) -> RpcHandle:
     """Start the RPC server.
 
@@ -53,6 +54,7 @@ def start_rpc_server(
             db_path=db_path,
             request_reindex=request_reindex,
             get_health_details=get_health_details,
+            get_roots=get_roots,
         )
 
         def _stop() -> None:
@@ -77,6 +79,7 @@ def start_rpc_server(
             db_path=db_path,
             request_reindex=request_reindex,
             get_health_details=get_health_details,
+            get_roots=get_roots,
         )
         server = UnixJsonServer(socket_path=socket_path, service=svc)
         server.start()

--- a/lampstand/rpc/service.py
+++ b/lampstand/rpc/service.py
@@ -20,6 +20,8 @@ from .messages import (
     QueryStats,
     ReindexRequest,
     ReindexResponse,
+    RootHint,
+    RootHintsResponse,
     SearchRequest,
     SearchResponse,
     SearchHit,
@@ -126,6 +128,10 @@ def _make_candidate_id(path: str, query: str) -> str:
     return "lampstand-local-query::sha256:" + hashlib.sha256(raw).hexdigest()[:32]
 
 
+def _make_root_id(path: Path) -> str:
+    return "lampstand-root::sha256:" + hashlib.sha256(str(path).encode()).hexdigest()[:32]
+
+
 class LampstandService:
     """Transport-agnostic service implementation.
 
@@ -142,11 +148,13 @@ class LampstandService:
         db_path: Path,
         request_reindex: Optional[Callable[[list[Path]], int]] = None,
         get_health_details: Optional[Callable[[], dict]] = None,
+        get_roots: Optional[Callable[[], list[Path]]] = None,
     ) -> None:
         self._db = IndexDB(db_path)
         self._db.open()
         self._request_reindex = request_reindex
         self._get_health_details = get_health_details
+        self._get_roots = get_roots
 
     def close(self) -> None:
         self._db.close()
@@ -177,6 +185,28 @@ class LampstandService:
             except Exception as e:  # pragma: no cover
                 details["health_cb_error"] = repr(e)
         return HealthResponse(ok=True, details=details)
+
+    def RootHints(self) -> RootHintsResponse:
+        """Return Lampstand-owned root hints without granting authorization.
+
+        Downstream enrichers such as Smart Tree must still apply their own
+        Policy Fabric profile before scanning any returned root.
+        """
+        roots = []
+        if self._get_roots:
+            for raw in self._get_roots():
+                path = Path(raw).expanduser().resolve()
+                roots.append(
+                    RootHint(
+                        source_root_id=_make_root_id(path),
+                        path=str(path),
+                        root_kind="local_root",
+                        freshness=None,
+                        classification="local_only",
+                        handling_tags=("local-only", "lampstand-root"),
+                    )
+                )
+        return RootHintsResponse(roots=tuple(roots), adapter_mode="rpc")
 
     def Reindex(self, req: ReindexRequest) -> ReindexResponse:
         if not self._request_reindex:

--- a/lampstand/rpc/unixjson.py
+++ b/lampstand/rpc/unixjson.py
@@ -105,6 +105,8 @@ class UnixJsonServer:
             return self.service.Stats()
         if method == "Health":
             return self.service.Health()
+        if method == "RootHints":
+            return self.service.RootHints()
         if method == "Reindex":
             r = ReindexRequest(**params)
             return self.service.Reindex(r)

--- a/tests/test_local_query_adapter.py
+++ b/tests/test_local_query_adapter.py
@@ -4,13 +4,12 @@ Covers:
 - DryRunResult shape and validation logic (no I/O)
 - LocalQueryRequest / LocalQueryResponse / PromotionCandidate shapes
 - LampstandService.DryRun() and LampstandService.LocalQuery()
-- unixjson dispatch for LocalQuery and DryRun methods
+- LampstandService.RootHints()
+- unixjson dispatch for LocalQuery, DryRun, and RootHints methods
 """
 
 from __future__ import annotations
 
-import hashlib
-import json
 import tempfile
 import threading
 import unittest
@@ -21,13 +20,12 @@ from lampstand.indexer import Indexer
 from lampstand.rpc.messages import (
     DryRunFinding,
     DryRunResult,
-    FileMetadata,
-    LocalHit,
     LocalQueryPolicy,
     LocalQueryRequest,
-    LocalQueryResponse,
     PromotionCandidate,
     QueryStats,
+    RootHint,
+    RootHintsResponse,
 )
 from lampstand.rpc.service import LampstandService, _make_candidate_id, _validate_dry_run
 from lampstand.rpc.unixjson import UnixJsonClient, UnixJsonServer
@@ -88,7 +86,6 @@ class TestDryRunValidation(unittest.TestCase):
         result = _validate_dry_run(self._req(limit=5000))
         warnings = [f for f in result.findings if f.field == "limit" and f.severity == "warning"]
         self.assertTrue(warnings)
-        # Should still be valid (warning != error)
         errors = [f for f in result.findings if f.severity == "error"]
         self.assertFalse(errors)
         self.assertTrue(result.valid)
@@ -112,7 +109,6 @@ class TestDryRunValidation(unittest.TestCase):
     def test_multiple_roots_mixed_validity(self):
         result = _validate_dry_run(self._req(roots=("/good/path", "bad/path")))
         self.assertFalse(result.valid)
-        # Only the bad root should produce an error.
         bad_findings = [f for f in result.findings if "roots[1]" in f.field]
         self.assertTrue(bad_findings)
         good_findings = [f for f in result.findings if "roots[0]" in f.field]
@@ -170,6 +166,17 @@ class TestMessageShapes(unittest.TestCase):
         self.assertTrue(p.allow_content_search)
         self.assertEqual(p.exclude_dirs, ())
 
+    def test_root_hint_fields(self):
+        hint = RootHint(source_root_id="root-1", path="/home/user/dev", root_kind="local_root")
+        self.assertEqual(hint.classification, "local_only")
+        self.assertIn("local-only", hint.handling_tags)
+
+    def test_root_hints_response_fields(self):
+        hint = RootHint(source_root_id="root-1", path="/home/user/dev")
+        resp = RootHintsResponse(roots=(hint,), adapter_mode="rpc")
+        self.assertEqual(resp.adapter_mode, "rpc")
+        self.assertEqual(len(resp.roots), 1)
+
     def test_dry_run_finding_fields(self):
         f = DryRunFinding(field="query", severity="error", message="bad")
         self.assertEqual(f.field, "query")
@@ -223,12 +230,21 @@ class TestLampstandServiceLocalQuery(unittest.TestCase):
         full_scan(indexer, [root])
         db.close()
 
-        self._svc = LampstandService(db_path=db_path)
-        self._root = root
+        self._root = root.resolve()
+        self._svc = LampstandService(db_path=db_path, get_roots=lambda: [self._root])
 
     def tearDown(self):
         self._svc.close()
         self._td.cleanup()
+
+    def test_root_hints_returns_configured_roots(self):
+        resp = self._svc.RootHints()
+        self.assertEqual(resp.adapter_mode, "rpc")
+        self.assertEqual(len(resp.roots), 1)
+        hint = resp.roots[0]
+        self.assertEqual(hint.path, str(self._root))
+        self.assertTrue(hint.source_root_id.startswith("lampstand-root::sha256:"))
+        self.assertEqual(hint.classification, "local_only")
 
     # --- dry-run via service ---
 
@@ -335,7 +351,8 @@ class TestUnixJsonLocalQuery(unittest.TestCase):
         full_scan(indexer, [root])
         db.close()
 
-        self._svc = LampstandService(db_path=db_path)
+        self._root = root.resolve()
+        self._svc = LampstandService(db_path=db_path, get_roots=lambda: [self._root])
         self._socket_path = root / "lamp.sock"
         self._server = UnixJsonServer(
             socket_path=self._socket_path,
@@ -350,6 +367,13 @@ class TestUnixJsonLocalQuery(unittest.TestCase):
         self._server.stop()
         self._svc.close()
         self._td.cleanup()
+
+    def test_root_hints_dispatch(self):
+        result = self._client.call("RootHints", {})
+        self.assertIn("roots", result)
+        self.assertEqual(result["adapter_mode"], "rpc")
+        self.assertEqual(len(result["roots"]), 1)
+        self.assertEqual(result["roots"][0]["path"], str(self._root))
 
     def test_local_query_dispatch(self):
         result = self._client.call("LocalQuery", {"query": "notes"})


### PR DESCRIPTION
## Summary

Adds a read-only Lampstand root-hints RPC path so downstream enrichers such as Smart Tree can consume Lampstand-owned local roots instead of guessing local state.

## Adds

- `RootHint` and `RootHintsResponse` message types
- `LampstandService.RootHints()`
- unixjson `RootHints` dispatch
- `RpcClient.root_hints()`
- daemon root provider wiring
- `lampstand roots` CLI command
- root-hints tests covering message shape, service behavior, and unixjson dispatch
- focused CI workflow for the Lampstand RPC contract

## Boundary

This does not authorize Smart Tree to scan anything. Root hints are discovery data only. Policy Fabric and the Smart Tree adapter still decide whether enrichment is allowed.

## Validation

CI should run:

```bash
python -m unittest tests.test_local_query_adapter -v
```
