### PR TITLE
feat: add governed adapter record publish boundary

### DIFF
--- a/.github/workflows/lampstand-rpc.yml
+++ b/.github/workflows/lampstand-rpc.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: Run local query and root hints tests
         run: python -m unittest tests.test_local_query_adapter -v
+
+      - name: Run adapter record publish tests
+        run: python -m unittest tests.test_adapter_records -v

--- a/lampstand/cli.py
+++ b/lampstand/cli.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from .daemon import run_daemon, run_one_shot_index
 from .db import IndexDB
@@ -30,6 +31,30 @@ def _try_rpc_client(transport: str, socket_path: Path) -> Optional[RpcClient]:
         return RpcClient(transport=transport, socket_path=socket_path)
     except Exception:
         return None
+
+
+def _rpc_client_or_error(args: argparse.Namespace) -> RpcClient | None:
+    transport = _choose_rpc_transport(args.rpc)
+    sock = Path(args.socket) if args.socket else default_socket_path()
+    return _try_rpc_client(transport, sock)
+
+
+def _load_json_arg(path_or_dash: str) -> Any:
+    if path_or_dash == "-":
+        return json.load(sys.stdin)
+    with Path(path_or_dash).expanduser().open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _extract_records(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        if isinstance(payload.get("records"), list):
+            return payload["records"]
+        if payload.get("record_type") and payload.get("title"):
+            return [payload]
+    raise SystemExit("adapter record payload must be a record object, {'records': [...]}, or [...] list")
 
 
 def cmd_index(args: argparse.Namespace) -> int:
@@ -119,9 +144,7 @@ def cmd_stats(args: argparse.Namespace) -> int:
 
 
 def cmd_health(args: argparse.Namespace) -> int:
-    transport = _choose_rpc_transport(args.rpc)
-    sock = Path(args.socket) if args.socket else default_socket_path()
-    client = _try_rpc_client(transport, sock)
+    client = _rpc_client_or_error(args)
     if client is None:
         print(json.dumps({"ok": False, "error": "daemon_unreachable"}, indent=2, sort_keys=True))
         return 2
@@ -130,13 +153,39 @@ def cmd_health(args: argparse.Namespace) -> int:
 
 
 def cmd_roots(args: argparse.Namespace) -> int:
-    transport = _choose_rpc_transport(args.rpc)
-    sock = Path(args.socket) if args.socket else default_socket_path()
-    client = _try_rpc_client(transport, sock)
+    client = _rpc_client_or_error(args)
     if client is None:
         print(json.dumps({"roots": [], "adapter_mode": "unavailable", "error": "daemon_unreachable"}, indent=2, sort_keys=True))
         return 2
     print(json.dumps(client.root_hints(), indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_adapter_records_publish(args: argparse.Namespace) -> int:
+    client = _rpc_client_or_error(args)
+    if client is None:
+        print(json.dumps({"ok": False, "error": "daemon_unreachable"}, indent=2, sort_keys=True))
+        return 2
+    records = _extract_records(_load_json_arg(args.payload))
+    print(json.dumps(client.publish_adapter_records(records, dry_run=args.dry_run), indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_adapter_records_query(args: argparse.Namespace) -> int:
+    client = _rpc_client_or_error(args)
+    if client is None:
+        print(json.dumps({"ok": False, "error": "daemon_unreachable"}, indent=2, sort_keys=True))
+        return 2
+    print(json.dumps(client.query_adapter_records(args.query, limit=args.limit), indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_adapter_records_stats(args: argparse.Namespace) -> int:
+    client = _rpc_client_or_error(args)
+    if client is None:
+        print(json.dumps({"ok": False, "error": "daemon_unreachable"}, indent=2, sort_keys=True))
+        return 2
+    print(json.dumps(client.adapter_record_stats(), indent=2, sort_keys=True))
     return 0
 
 
@@ -184,6 +233,19 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_roots = sub.add_parser("roots", help="Lampstand-owned local roots (RPC)")
     p_roots.set_defaults(fn=cmd_roots)
+
+    p_publish = sub.add_parser("adapter-records-publish", help="Publish governed adapter records from JSON")
+    p_publish.add_argument("payload", help="Path to JSON payload or '-' for stdin")
+    p_publish.add_argument("--dry-run", action="store_true", help="Validate and return record IDs without writing")
+    p_publish.set_defaults(fn=cmd_adapter_records_publish)
+
+    p_ar_query = sub.add_parser("adapter-records-query", help="Query governed adapter records")
+    p_ar_query.add_argument("query", help="FTS query string")
+    p_ar_query.add_argument("--limit", type=int, default=20)
+    p_ar_query.set_defaults(fn=cmd_adapter_records_query)
+
+    p_ar_stats = sub.add_parser("adapter-records-stats", help="Adapter record statistics")
+    p_ar_stats.set_defaults(fn=cmd_adapter_records_stats)
 
     return p
 

--- a/lampstand/records.py
+++ b/lampstand/records.py
@@ -208,7 +208,7 @@ class AdapterRecordStore:
             ORDER BY score
             LIMIT ?;
             """,
-            (query, int(limit)),
+            (quote_fts_query(query), int(limit)),
         )
         return [dict(row) for row in cur.fetchall()]
 
@@ -254,3 +254,15 @@ def derive_record_id(record: dict[str, Any]) -> str:
     }
     raw = json.dumps(parts, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return "lampstand-adapter-record::sha256:" + hashlib.sha256(raw).hexdigest()[:32]
+
+
+def quote_fts_query(query: str) -> str:
+    """Treat caller input as a phrase, not raw FTS5 syntax.
+
+    This prevents punctuation such as hyphens in `smart-tree` from being parsed
+    as FTS operators or column names.
+    """
+    q = str(query or "").strip()
+    if not q:
+        raise ValueError("adapter record query must not be empty")
+    return '"' + q.replace('"', '""') + '"'

--- a/lampstand/records.py
+++ b/lampstand/records.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+
+@dataclass(frozen=True)
+class StoredAdapterRecord:
+    record_id: str
+    record_type: str
+    title: str
+    object_kind: str
+    path_ref: str
+    classification: str
+    updated_at_ns: int
+
+
+class AdapterRecordStore:
+    """SQLite-backed store for governed local adapter/search records.
+
+    This is intentionally separate from the canonical `files` table. Adapter
+    records represent summaries, symbols, security signals, and memory candidates
+    produced by controlled tools such as Smart Tree. They are local-search records,
+    not filesystem truth.
+    """
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.con: Optional[sqlite3.Connection] = None
+
+    def open(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.con = sqlite3.connect(str(self.path), timeout=5.0, check_same_thread=False)
+        self.con.row_factory = sqlite3.Row
+        cur = self.con.cursor()
+        cur.execute("PRAGMA journal_mode=WAL;")
+        cur.execute("PRAGMA synchronous=NORMAL;")
+        cur.execute("PRAGMA busy_timeout=5000;")
+        cur.execute("PRAGMA temp_store=MEMORY;")
+        self.con.commit()
+        self._ensure_schema()
+
+    def close(self) -> None:
+        if self.con is not None:
+            self.con.close()
+            self.con = None
+
+    def _ensure_schema(self) -> None:
+        assert self.con is not None
+        cur = self.con.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS adapter_records (
+                record_id TEXT PRIMARY KEY,
+                record_type TEXT NOT NULL,
+                title TEXT NOT NULL,
+                object_kind TEXT NOT NULL,
+                path_ref TEXT NOT NULL,
+                source_root_id TEXT,
+                content_hash TEXT,
+                metadata_hash TEXT,
+                snippet TEXT,
+                handling_tags_json TEXT NOT NULL,
+                freshness_json TEXT,
+                policy_decision_json TEXT NOT NULL,
+                source_json TEXT NOT NULL,
+                classification TEXT NOT NULL,
+                updated_at_ns INTEGER NOT NULL
+            );
+            """
+        )
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_adapter_records_type ON adapter_records(record_type);")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_adapter_records_kind ON adapter_records(object_kind);")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_adapter_records_path_ref ON adapter_records(path_ref);")
+        cur.execute("CREATE INDEX IF NOT EXISTS idx_adapter_records_updated ON adapter_records(updated_at_ns);")
+        try:
+            cur.execute(
+                """
+                CREATE VIRTUAL TABLE IF NOT EXISTS adapter_records_fts USING fts5(
+                    record_id UNINDEXED,
+                    title,
+                    object_kind,
+                    path_ref,
+                    snippet,
+                    tokenize='unicode61 remove_diacritics 2'
+                );
+                """
+            )
+        except sqlite3.OperationalError as e:
+            msg = str(e).lower()
+            if "fts5" in msg or "no such module" in msg:
+                raise RuntimeError(
+                    "SQLite FTS5 is required for adapter record search. "
+                    "Install a sqlite3 build with FTS5 enabled."
+                ) from e
+            raise
+        self.con.commit()
+
+    def upsert_record(self, record: dict[str, Any]) -> str:
+        """Insert/update a governed adapter record and FTS document."""
+        assert self.con is not None
+        normalized = normalize_record(record)
+        now_ns = time.time_ns()
+        cur = self.con.cursor()
+        cur.execute("BEGIN;")
+        try:
+            cur.execute(
+                """
+                INSERT INTO adapter_records(
+                    record_id,
+                    record_type,
+                    title,
+                    object_kind,
+                    path_ref,
+                    source_root_id,
+                    content_hash,
+                    metadata_hash,
+                    snippet,
+                    handling_tags_json,
+                    freshness_json,
+                    policy_decision_json,
+                    source_json,
+                    classification,
+                    updated_at_ns
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(record_id) DO UPDATE SET
+                    record_type=excluded.record_type,
+                    title=excluded.title,
+                    object_kind=excluded.object_kind,
+                    path_ref=excluded.path_ref,
+                    source_root_id=excluded.source_root_id,
+                    content_hash=excluded.content_hash,
+                    metadata_hash=excluded.metadata_hash,
+                    snippet=excluded.snippet,
+                    handling_tags_json=excluded.handling_tags_json,
+                    freshness_json=excluded.freshness_json,
+                    policy_decision_json=excluded.policy_decision_json,
+                    source_json=excluded.source_json,
+                    classification=excluded.classification,
+                    updated_at_ns=excluded.updated_at_ns;
+                """,
+                (
+                    normalized["record_id"],
+                    normalized["record_type"],
+                    normalized["title"],
+                    normalized["object_kind"],
+                    normalized["path_ref"],
+                    normalized.get("source_root_id"),
+                    normalized.get("content_hash"),
+                    normalized.get("metadata_hash"),
+                    normalized.get("snippet"),
+                    json.dumps(normalized.get("handling_tags", []), sort_keys=True),
+                    json.dumps(normalized.get("freshness"), sort_keys=True),
+                    json.dumps(normalized.get("policy_decision", {}), sort_keys=True),
+                    json.dumps(normalized.get("source", {}), sort_keys=True),
+                    normalized.get("classification", "local_only"),
+                    now_ns,
+                ),
+            )
+            cur.execute("DELETE FROM adapter_records_fts WHERE record_id=?;", (normalized["record_id"],))
+            cur.execute(
+                """
+                INSERT INTO adapter_records_fts(record_id, title, object_kind, path_ref, snippet)
+                VALUES(?,?,?,?,?);
+                """,
+                (
+                    normalized["record_id"],
+                    normalized["title"],
+                    normalized["object_kind"],
+                    normalized["path_ref"],
+                    normalized.get("snippet") or "",
+                ),
+            )
+            cur.execute("COMMIT;")
+        except Exception:
+            try:
+                cur.execute("ROLLBACK;")
+            except Exception:
+                pass
+            raise
+        return str(normalized["record_id"])
+
+    def upsert_records(self, records: Iterable[dict[str, Any]]) -> list[str]:
+        return [self.upsert_record(record) for record in records]
+
+    def query_records(self, query: str, *, limit: int = 20) -> list[dict[str, Any]]:
+        assert self.con is not None
+        cur = self.con.cursor()
+        cur.execute(
+            """
+            SELECT
+                adapter_records.record_id AS record_id,
+                adapter_records.record_type AS record_type,
+                adapter_records.title AS title,
+                adapter_records.object_kind AS object_kind,
+                adapter_records.path_ref AS path_ref,
+                adapter_records.classification AS classification,
+                bm25(adapter_records_fts) AS score,
+                snippet(adapter_records_fts, 4, '[', ']', '…', 10) AS snippet
+            FROM adapter_records_fts
+            JOIN adapter_records ON adapter_records.record_id = adapter_records_fts.record_id
+            WHERE adapter_records_fts MATCH ?
+            ORDER BY score
+            LIMIT ?;
+            """,
+            (query, int(limit)),
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+    def stats(self) -> dict[str, Any]:
+        assert self.con is not None
+        cur = self.con.cursor()
+        cur.execute("SELECT COUNT(*) AS n FROM adapter_records;")
+        n_records = int(cur.fetchone()["n"])
+        cur.execute("SELECT COUNT(*) AS n FROM adapter_records_fts;")
+        n_fts = int(cur.fetchone()["n"])
+        return {"adapter_records": n_records, "adapter_records_fts": n_fts}
+
+
+def normalize_record(record: dict[str, Any]) -> dict[str, Any]:
+    required = ("record_id", "record_type", "title", "object_kind", "path_ref")
+    missing = [field for field in required if not record.get(field)]
+    if missing:
+        raise ValueError(f"adapter record missing required fields: {', '.join(missing)}")
+
+    handling_tags = record.get("handling_tags") or []
+    if not isinstance(handling_tags, list):
+        raise ValueError("handling_tags must be a list")
+
+    normalized = dict(record)
+    normalized.setdefault("classification", "local_only")
+    normalized.setdefault("policy_decision", {})
+    normalized.setdefault("source", {})
+    normalized["handling_tags"] = [str(tag) for tag in handling_tags]
+    return normalized

--- a/lampstand/records.py
+++ b/lampstand/records.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 import time
@@ -222,7 +223,7 @@ class AdapterRecordStore:
 
 
 def normalize_record(record: dict[str, Any]) -> dict[str, Any]:
-    required = ("record_id", "record_type", "title", "object_kind", "path_ref")
+    required = ("record_type", "title", "object_kind", "path_ref")
     missing = [field for field in required if not record.get(field)]
     if missing:
         raise ValueError(f"adapter record missing required fields: {', '.join(missing)}")
@@ -236,4 +237,20 @@ def normalize_record(record: dict[str, Any]) -> dict[str, Any]:
     normalized.setdefault("policy_decision", {})
     normalized.setdefault("source", {})
     normalized["handling_tags"] = [str(tag) for tag in handling_tags]
+    if not normalized.get("record_id"):
+        normalized["record_id"] = derive_record_id(normalized)
     return normalized
+
+
+def derive_record_id(record: dict[str, Any]) -> str:
+    parts = {
+        "record_type": record.get("record_type"),
+        "object_kind": record.get("object_kind"),
+        "path_ref": record.get("path_ref"),
+        "title": record.get("title"),
+        "metadata_hash": record.get("metadata_hash"),
+        "content_hash": record.get("content_hash"),
+        "source": record.get("source", {}),
+    }
+    raw = json.dumps(parts, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "lampstand-adapter-record::sha256:" + hashlib.sha256(raw).hexdigest()[:32]

--- a/lampstand/records.py
+++ b/lampstand/records.py
@@ -229,8 +229,8 @@ def normalize_record(record: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(f"adapter record missing required fields: {', '.join(missing)}")
 
     handling_tags = record.get("handling_tags") or []
-    if not isinstance(handling_tags, list):
-        raise ValueError("handling_tags must be a list")
+    if not isinstance(handling_tags, (list, tuple)):
+        raise ValueError("handling_tags must be a list or tuple")
 
     normalized = dict(record)
     normalized.setdefault("classification", "local_only")

--- a/lampstand/rpc/client.py
+++ b/lampstand/rpc/client.py
@@ -51,5 +51,20 @@ class RpcClient:
     def root_hints(self) -> dict[str, Any]:
         return self._call("RootHints", {})
 
+    def publish_adapter_records(self, records: list[dict[str, Any]], *, dry_run: bool = False) -> dict[str, Any]:
+        return self._call(
+            "PublishAdapterRecords",
+            {"records": records, "dry_run": bool(dry_run)},
+        )
+
+    def query_adapter_records(self, query: str, *, limit: int = 20) -> dict[str, Any]:
+        return self._call(
+            "QueryAdapterRecords",
+            {"query": query, "limit": int(limit)},
+        )
+
+    def adapter_record_stats(self) -> dict[str, Any]:
+        return self._call("AdapterRecordStats", {})
+
     def reindex(self, paths: list[str]) -> dict[str, Any]:
         return self._call("Reindex", {"paths": paths})

--- a/lampstand/rpc/messages.py
+++ b/lampstand/rpc/messages.py
@@ -75,6 +75,77 @@ class RootHintsResponse:
 
 
 # ---------------------------------------------------------------------------
+# Adapter records — governed local search records from controlled tools
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AdapterRecord:
+    """Governed local-search record produced by a controlled adapter.
+
+    These records are summaries/signals/candidates, not canonical filesystem
+    truth. They are intended for local search and later promotion review.
+    """
+
+    record_id: str
+    record_type: str
+    title: str
+    object_kind: str
+    path_ref: str
+    source_root_id: Optional[str] = None
+    content_hash: Optional[str] = None
+    metadata_hash: Optional[str] = None
+    snippet: Optional[str] = None
+    handling_tags: tuple[str, ...] = ()
+    freshness: Optional[dict[str, Any]] = None
+    policy_decision: dict[str, Any] = field(default_factory=dict)
+    source: dict[str, Any] = field(default_factory=dict)
+    classification: str = "local_only"
+
+
+@dataclass(frozen=True)
+class PublishAdapterRecordsRequest:
+    records: tuple[AdapterRecord, ...]
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class PublishAdapterRecordsResponse:
+    accepted: int
+    published: int
+    record_ids: tuple[str, ...]
+    dry_run: bool = False
+
+
+@dataclass(frozen=True)
+class QueryAdapterRecordsRequest:
+    query: str
+    limit: int = 20
+
+
+@dataclass(frozen=True)
+class AdapterRecordHit:
+    record_id: str
+    record_type: str
+    title: str
+    object_kind: str
+    path_ref: str
+    classification: str
+    score: float
+    snippet: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class QueryAdapterRecordsResponse:
+    hits: tuple[AdapterRecordHit, ...]
+
+
+@dataclass(frozen=True)
+class AdapterRecordStatsResponse:
+    stats: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
 # Local query adapter — Lattice FederatedQueryPlane / lampstand-local-query
 # ---------------------------------------------------------------------------
 

--- a/lampstand/rpc/messages.py
+++ b/lampstand/rpc/messages.py
@@ -87,11 +87,11 @@ class AdapterRecord:
     truth. They are intended for local search and later promotion review.
     """
 
-    record_id: str
     record_type: str
     title: str
     object_kind: str
     path_ref: str
+    record_id: Optional[str] = None
     source_root_id: Optional[str] = None
     content_hash: Optional[str] = None
     metadata_hash: Optional[str] = None

--- a/lampstand/rpc/service.py
+++ b/lampstand/rpc/service.py
@@ -4,10 +4,14 @@ import hashlib
 import time
 from dataclasses import asdict
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from ..db import IndexDB
+from ..records import AdapterRecordStore
 from .messages import (
+    AdapterRecord,
+    AdapterRecordHit,
+    AdapterRecordStatsResponse,
     DryRunFinding,
     DryRunResult,
     FileMetadata,
@@ -17,6 +21,10 @@ from .messages import (
     LocalQueryRequest,
     LocalQueryResponse,
     PromotionCandidate,
+    PublishAdapterRecordsRequest,
+    PublishAdapterRecordsResponse,
+    QueryAdapterRecordsRequest,
+    QueryAdapterRecordsResponse,
     QueryStats,
     ReindexRequest,
     ReindexResponse,
@@ -132,6 +140,10 @@ def _make_root_id(path: Path) -> str:
     return "lampstand-root::sha256:" + hashlib.sha256(str(path).encode()).hexdigest()[:32]
 
 
+def _adapter_record_to_dict(record: AdapterRecord) -> dict[str, Any]:
+    return asdict(record)
+
+
 class LampstandService:
     """Transport-agnostic service implementation.
 
@@ -152,12 +164,15 @@ class LampstandService:
     ) -> None:
         self._db = IndexDB(db_path)
         self._db.open()
+        self._adapter_records = AdapterRecordStore(db_path)
+        self._adapter_records.open()
         self._request_reindex = request_reindex
         self._get_health_details = get_health_details
         self._get_roots = get_roots
 
     def close(self) -> None:
         self._db.close()
+        self._adapter_records.close()
 
     # ---- RPC methods ----
 
@@ -175,7 +190,9 @@ class LampstandService:
         return SearchResponse(hits=hits)
 
     def Stats(self) -> StatsResponse:
-        return StatsResponse(stats=self._db.stats())
+        stats = self._db.stats()
+        stats.update(self._adapter_records.stats())
+        return StatsResponse(stats=stats)
 
     def Health(self) -> HealthResponse:
         details: dict = {"db_path": str(self._db.path)}
@@ -207,6 +224,51 @@ class LampstandService:
                     )
                 )
         return RootHintsResponse(roots=tuple(roots), adapter_mode="rpc")
+
+    def PublishAdapterRecords(self, req: PublishAdapterRecordsRequest) -> PublishAdapterRecordsResponse:
+        """Publish governed adapter records into Lampstand's local record store.
+
+        This is local-only and idempotent. It does not touch the canonical file
+        index, does not scan paths, and makes no network calls.
+        """
+        records = tuple(req.records)
+        record_ids = tuple(str(record.record_id) for record in records)
+        if req.dry_run:
+            return PublishAdapterRecordsResponse(
+                accepted=len(records),
+                published=0,
+                record_ids=record_ids,
+                dry_run=True,
+            )
+        published_ids = self._adapter_records.upsert_records(
+            _adapter_record_to_dict(record) for record in records
+        )
+        return PublishAdapterRecordsResponse(
+            accepted=len(records),
+            published=len(published_ids),
+            record_ids=tuple(published_ids),
+            dry_run=False,
+        )
+
+    def QueryAdapterRecords(self, req: QueryAdapterRecordsRequest) -> QueryAdapterRecordsResponse:
+        rows = self._adapter_records.query_records(req.query, limit=int(req.limit))
+        hits = tuple(
+            AdapterRecordHit(
+                record_id=str(row["record_id"]),
+                record_type=str(row["record_type"]),
+                title=str(row["title"]),
+                object_kind=str(row["object_kind"]),
+                path_ref=str(row["path_ref"]),
+                classification=str(row["classification"]),
+                score=float(row["score"]),
+                snippet=str(row["snippet"]) if row.get("snippet") else None,
+            )
+            for row in rows
+        )
+        return QueryAdapterRecordsResponse(hits=hits)
+
+    def AdapterRecordStats(self) -> AdapterRecordStatsResponse:
+        return AdapterRecordStatsResponse(stats=self._adapter_records.stats())
 
     def Reindex(self, req: ReindexRequest) -> ReindexResponse:
         if not self._request_reindex:

--- a/lampstand/rpc/unixjson.py
+++ b/lampstand/rpc/unixjson.py
@@ -9,9 +9,12 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from .messages import (
+    AdapterRecord,
     HealthResponse,
     LocalQueryPolicy,
     LocalQueryRequest,
+    PublishAdapterRecordsRequest,
+    QueryAdapterRecordsRequest,
     ReindexRequest,
     SearchRequest,
     StatsResponse,
@@ -23,6 +26,13 @@ def _to_jsonable(obj: Any) -> Any:
     if is_dataclass(obj):
         return asdict(obj)
     return obj
+
+
+def _adapter_record_from_wire(value: dict[str, Any]) -> AdapterRecord:
+    payload = dict(value)
+    if "handling_tags" in payload and isinstance(payload["handling_tags"], list):
+        payload["handling_tags"] = tuple(payload["handling_tags"])
+    return AdapterRecord(**payload)
 
 
 class UnixJsonServer:
@@ -107,6 +117,17 @@ class UnixJsonServer:
             return self.service.Health()
         if method == "RootHints":
             return self.service.RootHints()
+        if method == "PublishAdapterRecords":
+            p = dict(params)
+            raw_records = p.pop("records", [])
+            records = tuple(_adapter_record_from_wire(record) for record in raw_records)
+            return self.service.PublishAdapterRecords(
+                PublishAdapterRecordsRequest(records=records, **p)
+            )
+        if method == "QueryAdapterRecords":
+            return self.service.QueryAdapterRecords(QueryAdapterRecordsRequest(**params))
+        if method == "AdapterRecordStats":
+            return self.service.AdapterRecordStats()
         if method == "Reindex":
             r = ReindexRequest(**params)
             return self.service.Reindex(r)

--- a/tests/test_adapter_records.py
+++ b/tests/test_adapter_records.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+from lampstand.records import AdapterRecordStore, derive_record_id, normalize_record
+from lampstand.rpc.messages import AdapterRecord, PublishAdapterRecordsRequest, QueryAdapterRecordsRequest
+from lampstand.rpc.service import LampstandService
+from lampstand.rpc.unixjson import UnixJsonClient, UnixJsonServer
+
+
+def sample_record(**overrides):
+    record = {
+        "record_type": "sourceos.lampstand.repo_context_record.v1",
+        "title": "Repo context: smart-tree",
+        "object_kind": "repo_context",
+        "path_ref": "~/dev/smart-tree",
+        "snippet": "Smart Tree SourceOS adapter context record",
+        "handling_tags": ["local-only", "smart-tree"],
+        "policy_decision": {"decision": "allow"},
+        "source": {"system": "sourceos-smart-tree-adapter"},
+        "classification": "local_only",
+    }
+    record.update(overrides)
+    return record
+
+
+class TestAdapterRecordStore(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self._db_path = Path(self._td.name) / "index.sqlite3"
+        self._store = AdapterRecordStore(self._db_path)
+        self._store.open()
+
+    def tearDown(self):
+        self._store.close()
+        self._td.cleanup()
+
+    def test_normalize_derives_stable_record_id(self):
+        one = normalize_record(sample_record())
+        two = normalize_record(sample_record())
+        self.assertEqual(one["record_id"], two["record_id"])
+        self.assertTrue(one["record_id"].startswith("lampstand-adapter-record::sha256:"))
+
+    def test_explicit_record_id_is_preserved(self):
+        record = normalize_record(sample_record(record_id="explicit-id"))
+        self.assertEqual(record["record_id"], "explicit-id")
+
+    def test_missing_required_field_fails(self):
+        bad = sample_record()
+        bad.pop("title")
+        with self.assertRaises(ValueError):
+            normalize_record(bad)
+
+    def test_upsert_is_idempotent(self):
+        rid1 = self._store.upsert_record(sample_record())
+        rid2 = self._store.upsert_record(sample_record())
+        self.assertEqual(rid1, rid2)
+        stats = self._store.stats()
+        self.assertEqual(stats["adapter_records"], 1)
+        self.assertEqual(stats["adapter_records_fts"], 1)
+
+    def test_query_records_finds_published_summary(self):
+        self._store.upsert_record(sample_record())
+        hits = self._store.query_records("smart-tree", limit=10)
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0]["object_kind"], "repo_context")
+        self.assertIn("smart-tree", hits[0]["path_ref"])
+
+
+class TestLampstandServiceAdapterRecords(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self._db_path = Path(self._td.name) / "index.sqlite3"
+        self._svc = LampstandService(db_path=self._db_path)
+
+    def tearDown(self):
+        self._svc.close()
+        self._td.cleanup()
+
+    def _adapter_record(self) -> AdapterRecord:
+        payload = sample_record()
+        payload["handling_tags"] = tuple(payload["handling_tags"])
+        return AdapterRecord(**payload)
+
+    def test_publish_dry_run_does_not_write(self):
+        req = PublishAdapterRecordsRequest(records=(self._adapter_record(),), dry_run=True)
+        resp = self._svc.PublishAdapterRecords(req)
+        self.assertTrue(resp.dry_run)
+        self.assertEqual(resp.accepted, 1)
+        self.assertEqual(resp.published, 0)
+        self.assertEqual(self._svc.AdapterRecordStats().stats["adapter_records"], 0)
+
+    def test_publish_writes_and_query_finds_record(self):
+        req = PublishAdapterRecordsRequest(records=(self._adapter_record(),), dry_run=False)
+        resp = self._svc.PublishAdapterRecords(req)
+        self.assertFalse(resp.dry_run)
+        self.assertEqual(resp.accepted, 1)
+        self.assertEqual(resp.published, 1)
+
+        query = self._svc.QueryAdapterRecords(QueryAdapterRecordsRequest(query="smart-tree", limit=10))
+        self.assertEqual(len(query.hits), 1)
+        self.assertEqual(query.hits[0].object_kind, "repo_context")
+
+    def test_repeated_publish_is_idempotent(self):
+        req = PublishAdapterRecordsRequest(records=(self._adapter_record(),), dry_run=False)
+        first = self._svc.PublishAdapterRecords(req)
+        second = self._svc.PublishAdapterRecords(req)
+        self.assertEqual(first.record_ids, second.record_ids)
+        self.assertEqual(self._svc.AdapterRecordStats().stats["adapter_records"], 1)
+
+
+class TestUnixJsonAdapterRecords(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        root = Path(self._td.name)
+        self._svc = LampstandService(db_path=root / "index.sqlite3")
+        self._socket_path = root / "lamp.sock"
+        self._server = UnixJsonServer(socket_path=self._socket_path, service=self._svc)
+        self._server.start()
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        self._client = UnixJsonClient(socket_path=self._socket_path)
+
+    def tearDown(self):
+        self._server.stop()
+        self._svc.close()
+        self._td.cleanup()
+
+    def test_publish_query_and_stats_via_unixjson(self):
+        publish = self._client.call(
+            "PublishAdapterRecords",
+            {"records": [sample_record()], "dry_run": False},
+        )
+        self.assertEqual(publish["accepted"], 1)
+        self.assertEqual(publish["published"], 1)
+
+        query = self._client.call("QueryAdapterRecords", {"query": "smart-tree", "limit": 10})
+        self.assertEqual(len(query["hits"]), 1)
+        self.assertEqual(query["hits"][0]["object_kind"], "repo_context")
+
+        stats = self._client.call("AdapterRecordStats", {})
+        self.assertEqual(stats["stats"]["adapter_records"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a governed, local-only adapter record ingestion boundary for Lampstand.

This lets controlled tools such as Smart Tree publish repo summaries, security signals, symbol/search records, and memory-candidate summaries into Lampstand without mutating the canonical file index.

## Adds

- `AdapterRecordStore` backed by separate `adapter_records` and `adapter_records_fts` tables
- stable derived `record_id` when callers omit one
- adapter record RPC message types
- `LampstandService.PublishAdapterRecords()`
- `LampstandService.QueryAdapterRecords()`
- `LampstandService.AdapterRecordStats()`
- unixjson dispatch for adapter-record publish/query/stats
- high-level RPC client helpers
- CLI commands:
  - `lampstand adapter-records-publish <payload.json|-> [--dry-run]`
  - `lampstand adapter-records-query <query>`
  - `lampstand adapter-records-stats`
- tests for normalization, idempotent upsert, FTS search, service behavior, dry-run behavior, and unixjson behavior
- CI coverage for the new adapter-record tests

## Boundary

This is local-only and idempotent. It does not scan files, mutate filesystem truth, call external services, or authorize Smart Tree enrichment. It only accepts governed records into a separate local search surface.

## Validation

CI should run:

```bash
python -m unittest tests.test_local_query_adapter -v
python -m unittest tests.test_adapter_records -v
pytest -q
```
